### PR TITLE
FIX: Add public property Serializor\ClosureStream::$context

### DIFF
--- a/src/ClosureStream.php
+++ b/src/ClosureStream.php
@@ -46,6 +46,8 @@ class ClosureStream
 
     protected $pointer = 0;
 
+    public $context;
+
     function stream_open($path, $mode, $options, &$opened_path)
     {
         $this->content = "<?php\n" . substr($path, strlen(static::STREAM_PROTO . '://')) . ";";
@@ -119,5 +121,4 @@ class ClosureStream
             static::$isRegistered = stream_wrapper_register(static::STREAM_PROTO, __CLASS__);
         }
     }
-
- }
+}


### PR DESCRIPTION
As of PHP 8.2 the creation of properties is deprecated.