### PR TITLE
FEAT: Use platform specific secret generators in `Serializor`

### DIFF
--- a/Serializor.php
+++ b/Serializor.php
@@ -1,9 +1,17 @@
 <?php
 
+declare(strict_types=1);
+
 use Serializor\Codec;
+use Serializor\SecretGenerators\LinuxSecretGenerator;
+use Serializor\SecretGenerators\MacSecretGenerator;
+use Serializor\SecretGenerators\SecretGenerationException;
+use Serializor\SecretGenerators\WindowsSecretGenerator;
 use Serializor\SerializerError;
 use Serializor\Transformers\AnonymousClassTransformer;
 use Serializor\Transformers\ClosureTransformer;
+
+use const PHP_OS_FAMILY;
 
 /**
  * Serializor class responsible for serializing and deserializing data,
@@ -33,35 +41,6 @@ class Serializor
 
     /** @var Closure|null Custom function for resolving variables used in closures */
     private static ?Closure $resolveUseVarsFunc = null;
-
-    /**
-     * List of files used to generate a machine-specific secret key.
-     * The library attempts to generate a secret based on these files,
-     * making it possible to serialize and unserialize data on the same
-     * machine, while adding protection from deserialization on different
-     * machines.
-     */
-    public const AUTOSECRET_FILES = [
-        'primary' => [
-            '/var/lib/dbus',
-            '/etc/machine-id',
-            '/proc/sys/kernel/random/boot_id',
-            '/sys/class/dmi/id/product_uuid',
-            '/etc/hostconfig',
-            '/etc/hostid',
-            '/etc/rc.conf',
-            '/var/db/hostid',
-            'C:\ProgramData\Microsoft\Windows\DeviceMetadataCache\dmrc.idx',
-            'C:\Windows\System32\spp\store\2.0\tokens.dat',
-            'C:\Windows\System32\drivers\etc\hosts',
-            '/etc/hosts',
-        ],
-        'secondary' => [
-            '/proc/cpuinfo',
-            'C:\Windows\System32\license.rtf',
-            '/Library/Preferences/com.apple.TimeMachine.plist',
-        ],
-    ];
 
     /**
      * Serializes the given value using the default Serializor instance.
@@ -165,60 +144,22 @@ class Serializor
     }
 
     /**
-     * Automatically identifies a machine-specific secret string by examining
-     * a combination of system files. This secret is intended to be unique to the
-     * machine and persistent across reboots.
+     * Automatically identifies a machine-specific secret string.
+     * This secret is intended to be unique to the machine and persistent across reboots.
      *
      * @return string A machine-specific secret key
-     * @throws SerializerError If no suitable secret could be generated
+     * @throws SerializerError           If no suitable secret generator could be located
+     * @throws SecretGenerationException If no suitable secret could be generated
      */
     public static function getMachineSecret(): string
     {
-        $primary = null;
-        $secondary = null;
+        $secretGenerator = match (PHP_OS_FAMILY) {
+            'Windows' => new WindowsSecretGenerator(),
+            'Darwin' => new MacSecretGenerator(),
+            'Linux' => new LinuxSecretGenerator(),
+            default => throw new SerializerError('Could not locate suitable secret generator for ' . PHP_OS_FAMILY . 'operating system')
+        };
 
-        foreach (self::AUTOSECRET_FILES['primary'] as $candidate) {
-            if ($primary = self::getSecretFromPath($candidate)) {
-                break;
-            }
-        }
-
-        foreach (self::AUTOSECRET_FILES['secondary'] as $candidate) {
-            if ($secondary = self::getSecretFromPath($candidate)) {
-                break;
-            }
-        }
-
-        if ($primary !== null && $secondary !== null) {
-            return md5(serialize([$primary, $secondary]));
-        }
-
-        throw new SerializerError('Unable to obtain a machine-specific secret');
-    }
-
-    /**
-     * Generates a secret string based on the metadata and contents of the given file.
-     *
-     * @param string $path The file path to use for generating the secret
-     *
-     * @return string|null The generated secret string, or null if the file is not readable
-     */
-    private static function getSecretFromPath(string $path): ?string
-    {
-        if (!is_file($path) || !\is_readable($path)) {
-            return null;
-        }
-
-        try {
-            $fp = fopen($path, 'rb');
-            $data = fread($fp, 65536); // Read up to 64KB of file content
-            $stat = fstat($fp); // Get file metadata
-            $data .= serialize($stat); // Append serialized file metadata
-            fclose($fp);
-
-            return $data;
-        } catch (Throwable) {
-            return null;
-        }
+        return $secretGenerator->generate();
     }
 }

--- a/Serializor.php
+++ b/Serializor.php
@@ -11,8 +11,6 @@ use Serializor\SerializerError;
 use Serializor\Transformers\AnonymousClassTransformer;
 use Serializor\Transformers\ClosureTransformer;
 
-use const PHP_OS_FAMILY;
-
 /**
  * Serializor class responsible for serializing and deserializing data,
  * particularly closures and anonymous classes. This class allows for the

--- a/Serializor.php
+++ b/Serializor.php
@@ -3,10 +3,12 @@
 declare(strict_types=1);
 
 use Serializor\Codec;
+use Serializor\SecretGenerators\BsdSecretGenerator;
 use Serializor\SecretGenerators\FallbackSecretGenerator;
 use Serializor\SecretGenerators\LinuxSecretGenerator;
 use Serializor\SecretGenerators\MacSecretGenerator;
 use Serializor\SecretGenerators\SecretGenerationException;
+use Serializor\SecretGenerators\SolarisSecretGenerator;
 use Serializor\SecretGenerators\WindowsSecretGenerator;
 use Serializor\SerializerError;
 use Serializor\Transformers\AnonymousClassTransformer;
@@ -156,6 +158,8 @@ class Serializor
                 'Windows' => new WindowsSecretGenerator(),
                 'Darwin' => new MacSecretGenerator(),
                 'Linux' => new LinuxSecretGenerator(),
+                'Solaris' => new SolarisSecretGenerator(),
+                'BSD' => new BsdSecretGenerator(),
                 default => throw new SerializerError(
                     'Could not locate suitable secret generator for ' . PHP_OS_FAMILY . ' operating system'
                 )

--- a/src/SecretGenerators/BsdSecretGenerator.php
+++ b/src/SecretGenerators/BsdSecretGenerator.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Serializor\SecretGenerators;
+
+use function hash;
+
+final class BsdSecretGenerator implements SecretGenerator
+{
+    use CanExecuteCommand;
+
+    /** @throws SecretGenerationException If no suitable secret could be generated */
+    public function generate(): string
+    {
+        $cpuId = $this->executeCommand('dmesg | grep -m 1 \'CPU:\'')
+            ?: $this->executeCommand('sysctl -n hw.model')
+            ?: throw new SecretGenerationException('CPU ID could not be read');
+
+        $macAddress = $this->executeCommand('ifconfig | grep -E \'ether\' | awk \'{print $2}\'')
+            ?: throw new SecretGenerationException('MAC Address could not be read');
+
+        $machineGuid = $this->executeCommand('kenv -q smbios.system.uuid')
+            ?: $this->executeCommand('sysctl -n hw.uuid')
+            ?: throw new SecretGenerationException('Machine GUID could not be read');
+
+        return hash('sha256', $cpuId . $macAddress . $machineGuid);
+    }
+}

--- a/src/SecretGenerators/CanExecuteCommand.php
+++ b/src/SecretGenerators/CanExecuteCommand.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Serializor\SecretGenerators;
+
+use function fclose;
+use function proc_close;
+use function proc_open;
+use function stream_get_contents;
+use function trim;
+
+trait CanExecuteCommand
+{
+    private function executeCommand(string|array $command): string
+    {
+        $process = proc_open(
+            command: $command,
+            descriptor_spec: [
+                ['pipe', 'r'],
+                ['pipe', 'w'],
+                ['pipe', 'w']
+            ],
+            pipes: $pipes,
+            options: [
+                'suppress_errors' => true,
+            ],
+        );
+
+        if ($process === false) {
+            return '';
+        }
+
+        fclose($pipes[0]);
+
+        $result = stream_get_contents($pipes[1]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        proc_close($process);
+
+        return trim($result);
+    }
+}

--- a/src/SecretGenerators/FallbackSecretGenerator.php
+++ b/src/SecretGenerators/FallbackSecretGenerator.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Serializor\SecretGenerators;
+
+use Throwable;
+
+use function file_exists;
+use function file_get_contents;
+use function file_put_contents;
+use function hash;
+use function random_bytes;
+
+final class FallbackSecretGenerator implements SecretGenerator
+{
+    public function __construct(
+        private string $pathToSecretFile,
+    ) {}
+
+    /** @throws SecretGenerationException If no suitable secret could be generated */
+    public function generate(): string
+    {
+        if (!file_exists($this->pathToSecretFile)) {
+            $hash = hash('sha256', random_bytes(32));
+
+            file_put_contents($this->pathToSecretFile, $hash);
+        }
+
+        return file_get_contents($this->pathToSecretFile)
+            ?: throw new SecretGenerationException('Could not retrieve fallback secret');
+    }
+}

--- a/src/SecretGenerators/LinuxSecretGenerator.php
+++ b/src/SecretGenerators/LinuxSecretGenerator.php
@@ -10,15 +10,17 @@ use function hash;
 
 final class LinuxSecretGenerator implements SecretGenerator
 {
+    use CanExecuteCommand;
+
     /** @throws SecretGenerationException If no suitable secret could be generated */
     public function generate(): string
     {
-        $cpuId = shell_exec('grep -m 1 \'Serial\' /proc/cpuinfo | awk \'{print $3}\'')
-            ?: shell_exec('cat /proc/cpuinfo | grep \'model name\' | head -1 | awk -F\': \' \'{print $2}\'')
+        $cpuId = $this->executeCommand('grep -m 1 \'Serial\' /proc/cpuinfo | awk \'{print $3}\'')
+            ?: $this->executeCommand('cat /proc/cpuinfo | grep \'model name\' | head -1 | awk -F\': \' \'{print $2}\'')
             ?: throw new SecretGenerationException('CPU ID could not be read');
 
-        $macAddress = shell_exec('ip link show | awk \'/ether/ {print $2}\' | head -n 1')
-            ?: shell_exec('ifconfig -a | grep -Po \'HWaddr \K.*$\' | head -n 1')
+        $macAddress = $this->executeCommand('ip link show 2>/dev/null | awk \'/ether/ {print $2}\' 2>/dev/null | head -n 1 2>/dev/null')
+            ?: $this->executeCommand('ifconfig -a | grep -Po \'HWaddr \K.*$\' | head -n 1')
             ?: throw new SecretGenerationException('MAC Address could not be read');
 
         if (!file_exists('/etc/machine-id')) {

--- a/src/SecretGenerators/LinuxSecretGenerator.php
+++ b/src/SecretGenerators/LinuxSecretGenerator.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Serializor\SecretGenerators;
+
+use function file_exists;
+use function file_get_contents;
+use function hash;
+
+final class LinuxSecretGenerator implements SecretGenerator
+{
+    /** @throws SecretGenerationException If no suitable secret could be generated */
+    public function generate(): string
+    {
+        $cpuId = shell_exec('grep -m 1 \'Serial\' /proc/cpuinfo | awk \'{print $3}\'')
+            ?: shell_exec('cat /proc/cpuinfo | grep \'model name\' | head -1 | awk -F\': \' \'{print $2}\'')
+            ?: throw new SecretGenerationException('CPU ID could not be read');
+
+        $macAddress = shell_exec('ip link show | awk \'/ether/ {print $2}\' | head -n 1')
+            ?: shell_exec('ifconfig -a | grep -Po \'HWaddr \K.*$\' | head -n 1')
+            ?: throw new SecretGenerationException('MAC Address could not be read');
+
+        if (!file_exists('/etc/machine-id')) {
+            throw new SecretGenerationException('Machine ID could not be read');
+        }
+
+        $machineId = file_get_contents('/etc/machine-id')
+            ?: throw new SecretGenerationException('Machine ID could not be read');
+
+        return hash('sha256', $cpuId . $macAddress . $machineId);
+    }
+}

--- a/src/SecretGenerators/MacSecretGenerator.php
+++ b/src/SecretGenerators/MacSecretGenerator.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Serializor\SecretGenerators;
+
+use function hash;
+use function shell_exec;
+
+final class MacSecretGenerator implements SecretGenerator
+{
+    /** @throws SecretGenerationException If no suitable secret could be generated */
+    public function generate(): string
+    {
+        $cpuId = shell_exec('sysctl -n machdep.cpu.brand_string')
+            ?: throw new SecretGenerationException('CPU ID could not be read');
+
+        $macAddress = shell_exec('ifconfig en0 | grep ether | awk \'{print $2}\'')
+            ?: throw new SecretGenerationException('MAC Address could not be read');
+
+        $ioPlatformUuid = shell_exec('ioreg -rd1 -c IOPlatformExpertDevice | grep IOPlatformUUID | awk \'{print $3}\' | sed \'s/\"//g\'')
+            ?: throw new SecretGenerationException('IOPlatformUUID could not be read');
+
+        return hash('sha256', $cpuId . $macAddress . $ioPlatformUuid);
+    }
+}

--- a/src/SecretGenerators/MacSecretGenerator.php
+++ b/src/SecretGenerators/MacSecretGenerator.php
@@ -5,20 +5,21 @@ declare(strict_types=1);
 namespace Serializor\SecretGenerators;
 
 use function hash;
-use function shell_exec;
 
 final class MacSecretGenerator implements SecretGenerator
 {
+    use CanExecuteCommand;
+
     /** @throws SecretGenerationException If no suitable secret could be generated */
     public function generate(): string
     {
-        $cpuId = shell_exec('sysctl -n machdep.cpu.brand_string')
+        $cpuId = $this->executeCommand('sysctl -n machdep.cpu.brand_string')
             ?: throw new SecretGenerationException('CPU ID could not be read');
 
-        $macAddress = shell_exec('ifconfig en0 | grep ether | awk \'{print $2}\'')
+        $macAddress = $this->executeCommand('ifconfig en0 | grep ether | awk \'{print $2}\'')
             ?: throw new SecretGenerationException('MAC Address could not be read');
 
-        $ioPlatformUuid = shell_exec('ioreg -rd1 -c IOPlatformExpertDevice | grep IOPlatformUUID | awk \'{print $3}\' | sed \'s/\"//g\'')
+        $ioPlatformUuid = $this->executeCommand('ioreg -rd1 -c IOPlatformExpertDevice | grep IOPlatformUUID | awk \'{print $3}\' | sed \'s/\"//g\'')
             ?: throw new SecretGenerationException('IOPlatformUUID could not be read');
 
         return hash('sha256', $cpuId . $macAddress . $ioPlatformUuid);

--- a/src/SecretGenerators/SecretGenerationException.php
+++ b/src/SecretGenerators/SecretGenerationException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Serializor\SecretGenerators;
+
+use RuntimeException;
+
+final class SecretGenerationException extends RuntimeException {}

--- a/src/SecretGenerators/SecretGenerator.php
+++ b/src/SecretGenerators/SecretGenerator.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Serializor\SecretGenerators;
+
+interface SecretGenerator
+{
+    /** @throws SecretGenerationException If no suitable secret could be generated */
+    public function generate(): string;
+}

--- a/src/SecretGenerators/SecretGeneratorFactory.php
+++ b/src/SecretGenerators/SecretGeneratorFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Serializor\SecretGenerators;
+
+final class SecretGeneratorFactory
+{
+    public function __construct(
+        private string $pathToSecretFile,
+    ) {}
+
+    public function create(string $platform): SecretGenerator
+    {
+        return match ($platform) {
+            'Windows' => new WindowsSecretGenerator(),
+            'Linux'   => new LinuxSecretGenerator(),
+            'Darwin'  => new MacSecretGenerator(),
+            'Solaris' => new SolarisSecretGenerator(),
+            'BSD'     => new BsdSecretGenerator(),
+            default   => new FallbackSecretGenerator($this->pathToSecretFile),
+        };
+    }
+}

--- a/src/SecretGenerators/SolarisSecretGenerator.php
+++ b/src/SecretGenerators/SolarisSecretGenerator.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Serializor\SecretGenerators;
+
+use function hash;
+
+final class SolarisSecretGenerator implements SecretGenerator
+{
+    use CanExecuteCommand;
+
+    /** @throws SecretGenerationException If no suitable secret could be generated */
+    public function generate(): string
+    {
+        $cpuId = $this->executeCommand('psrinfo -pv | grep \'The physical processor\' | awk \'{print $5}\'')
+            ?: $this->executeCommand('prtdiag | grep \'Processor\'')
+            ?: throw new SecretGenerationException('CPU ID could not be read');
+
+        $macAddress = $this->executeCommand('ifconfig -a | grep ether | awk \'{print $2}\'')
+            ?: throw new SecretGenerationException('MAC Address could not be read');
+
+        $machineGuid = $this->executeCommand('hostid')
+            ?: $this->executeCommand('/usr/bin/sneep')
+            ?: throw new SecretGenerationException('Machine GUID could not be read');
+
+        return hash('sha256', $cpuId . $macAddress . $machineGuid);
+    }
+}

--- a/src/SecretGenerators/WindowsSecretGenerator.php
+++ b/src/SecretGenerators/WindowsSecretGenerator.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Serializor\SecretGenerators;
+
+use function hash;
+use function shell_exec;
+
+final class WindowsSecretGenerator implements SecretGenerator
+{
+    /** @throws SecretGenerationException If no suitable secret could be generated */
+    public function generate(): string
+    {
+        $cpuId = shell_exec('wmic cpu get ProcessorId')
+            ?: throw new SecretGenerationException('CPU ID could not be read');
+
+        $macAddress = shell_exec('getmac')
+            ?: shell_exec('wmic nic where (NetEnabled=true) get MACAddress')
+            ?: throw new SecretGenerationException('MAC Address could not be read');
+
+        $machineGuid = shell_exec('reg query HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Cryptography /v MachineGuid')
+            ?: throw new SecretGenerationException('Machine GUID could not be read');
+
+        return hash('sha256', $cpuId . $macAddress . $machineGuid);
+    }
+}

--- a/src/SecretGenerators/WindowsSecretGenerator.php
+++ b/src/SecretGenerators/WindowsSecretGenerator.php
@@ -5,21 +5,22 @@ declare(strict_types=1);
 namespace Serializor\SecretGenerators;
 
 use function hash;
-use function shell_exec;
 
 final class WindowsSecretGenerator implements SecretGenerator
 {
+    use CanExecuteCommand;
+
     /** @throws SecretGenerationException If no suitable secret could be generated */
     public function generate(): string
     {
-        $cpuId = shell_exec('wmic cpu get ProcessorId')
+        $cpuId = $this->executeCommand('wmic cpu get ProcessorId')
             ?: throw new SecretGenerationException('CPU ID could not be read');
 
-        $macAddress = shell_exec('getmac')
-            ?: shell_exec('wmic nic where (NetEnabled=true) get MACAddress')
+        $macAddress = $this->executeCommand('getmac')
+            ?: $this->executeCommand('wmic nic where (NetEnabled=true) get MACAddress')
             ?: throw new SecretGenerationException('MAC Address could not be read');
 
-        $machineGuid = shell_exec('reg query HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Cryptography /v MachineGuid')
+        $machineGuid = $this->executeCommand('reg query HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Cryptography /v MachineGuid')
             ?: throw new SecretGenerationException('Machine GUID could not be read');
 
         return hash('sha256', $cpuId . $macAddress . $machineGuid);

--- a/tests/Unit/SecretGenerators/BsdSecretGeneratorTest.php
+++ b/tests/Unit/SecretGenerators/BsdSecretGeneratorTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\SecretGenerators;
+
+use Serializor\SecretGenerators\BsdSecretGenerator;
+use Serializor\SecretGenerators\SecretGenerationException;
+
+test('generates a secret hash on BSD machines', function (): void {
+    $secretGenerator = new BsdSecretGenerator();
+
+    $actual = $secretGenerator->generate();
+
+    expect($actual)->not()->toBeNull();
+})->coversClass(BsdSecretGenerator::class)
+    ->skip(fn(): bool => PHP_OS_FAMILY !== 'BSD', 'This test is skipped on [' . PHP_OS_FAMILY . '].');
+
+test('throws an exception if secret hash could not be generated', function (): void {
+    $secretGenerator = new BsdSecretGenerator();
+
+    $secretGenerator->generate();
+})
+    ->throws(SecretGenerationException::class)
+    ->coversClass(BsdSecretGenerator::class)
+    ->skip(fn(): bool => PHP_OS_FAMILY === 'BSD', 'This test is skipped on [BSD].');

--- a/tests/Unit/SecretGenerators/CanExecuteCommandTest.php
+++ b/tests/Unit/SecretGenerators/CanExecuteCommandTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\SecretGenerators;
+
+use Serializor\SecretGenerators\CanExecuteCommand;
+
+use function restore_error_handler;
+use function set_error_handler;
+
+use const E_WARNING;
+
+test('executes a command and returns its result', function (): void {
+    $class = createClassThatCanExecuteCommand();
+
+    $actual = $class('echo Hello');
+
+    expect($actual)->toBe('Hello');
+})
+    ->coversClass(CanExecuteCommand::class);
+
+test('returns empty string when error occurred', function (): void {
+    $class = createClassThatCanExecuteCommand();
+    set_error_handler(fn(): bool => true, E_WARNING);
+
+    $actual = $class(['a', false]);
+
+    restore_error_handler();
+    expect($actual)->toBe('');
+})
+    ->coversClass(CanExecuteCommand::class);
+
+function createClassThatCanExecuteCommand(): object
+{
+    return new class {
+        use CanExecuteCommand;
+
+        public function __invoke(string|array $command): string
+        {
+            return $this->executeCommand($command);
+        }
+    };
+}

--- a/tests/Unit/SecretGenerators/FallbackGeneratorTest.php
+++ b/tests/Unit/SecretGenerators/FallbackGeneratorTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\SecretGenerators;
+
+use Serializor\SecretGenerators\FallbackSecretGenerator;
+use Serializor\SecretGenerators\SecretGenerationException;
+
+use function file_exists;
+use function hash;
+use function random_bytes;
+use function restore_error_handler;
+use function set_error_handler;
+use function unlink;
+
+use const DIRECTORY_SEPARATOR;
+use const E_WARNING;
+
+test('generates a secret locally', function (): void {
+    $path = createPathToFileThatDoesNotExist();
+    $secretGenerator = new FallbackSecretGenerator($path);
+
+    $actual = $secretGenerator->generate();
+
+    expect($actual)->not()->toBeNull();
+    expect($path)->toBeFile();
+    unlink($path);
+})->coversClass(FallbackSecretGenerator::class);
+
+test('throws an exception if secret hash could not be generated', function (): void {
+    $secretGenerator = new FallbackSecretGenerator('.');
+    set_error_handler(fn(): bool => true, E_WARNING);
+
+    $secretGenerator->generate();
+
+    restore_error_handler();
+})
+    ->throws(SecretGenerationException::class)
+    ->coversClass(FallbackSecretGenerator::class);
+
+function createPathToFileThatDoesNotExist(): string
+{
+    do {
+        $path = __DIR__ . DIRECTORY_SEPARATOR . hash('sha256', random_bytes(32));
+    } while (file_exists($path));
+
+    return $path;
+}

--- a/tests/Unit/SecretGenerators/FallbackGeneratorTest.php
+++ b/tests/Unit/SecretGenerators/FallbackGeneratorTest.php
@@ -26,7 +26,8 @@ test('generates a secret locally', function (): void {
     expect($actual)->not()->toBeNull();
     expect($path)->toBeFile();
     unlink($path);
-})->coversClass(FallbackSecretGenerator::class);
+})
+    ->coversClass(FallbackSecretGenerator::class);
 
 test('throws an exception if secret hash could not be generated', function (): void {
     $secretGenerator = new FallbackSecretGenerator('.');

--- a/tests/Unit/SecretGenerators/LinuxSecretGeneratorTest.php
+++ b/tests/Unit/SecretGenerators/LinuxSecretGeneratorTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\SecretGenerators;
+
+use Serializor\SecretGenerators\LinuxSecretGenerator;
+use Serializor\SecretGenerators\SecretGenerationException;
+
+test('generates a secret hash on linux machines', function (): void {
+    $secretGenerator = new LinuxSecretGenerator();
+
+    $actual = $secretGenerator->generate();
+
+    expect($actual)->not()->toBeNull();
+})->coversClass(LinuxSecretGenerator::class)->onlyOnLinux();
+
+test('throws an exception if secret hash could not be generated', function (): void {
+    $secretGenerator = new LinuxSecretGenerator();
+
+    $secretGenerator->generate();
+})->throws(SecretGenerationException::class)->skipOnLinux();

--- a/tests/Unit/SecretGenerators/LinuxSecretGeneratorTest.php
+++ b/tests/Unit/SecretGenerators/LinuxSecretGeneratorTest.php
@@ -19,4 +19,6 @@ test('throws an exception if secret hash could not be generated', function (): v
     $secretGenerator = new LinuxSecretGenerator();
 
     $secretGenerator->generate();
-})->throws(SecretGenerationException::class)->skipOnLinux();
+})
+    ->throws(SecretGenerationException::class)->skipOnLinux()
+    ->coversClass(LinuxSecretGenerator::class)->onlyOnLinux();

--- a/tests/Unit/SecretGenerators/LinuxSecretGeneratorTest.php
+++ b/tests/Unit/SecretGenerators/LinuxSecretGeneratorTest.php
@@ -13,12 +13,15 @@ test('generates a secret hash on linux machines', function (): void {
     $actual = $secretGenerator->generate();
 
     expect($actual)->not()->toBeNull();
-})->coversClass(LinuxSecretGenerator::class)->onlyOnLinux();
+})
+    ->coversClass(LinuxSecretGenerator::class)
+    ->skip(fn(): bool => PHP_OS_FAMILY !== 'Linux', 'This test is skipped on [' . PHP_OS_FAMILY . '].');
 
 test('throws an exception if secret hash could not be generated', function (): void {
     $secretGenerator = new LinuxSecretGenerator();
 
     $secretGenerator->generate();
 })
-    ->throws(SecretGenerationException::class)->skipOnLinux()
-    ->coversClass(LinuxSecretGenerator::class)->onlyOnLinux();
+    ->throws(SecretGenerationException::class)
+    ->coversClass(LinuxSecretGenerator::class)
+    ->skip(fn(): bool => PHP_OS_FAMILY === 'Linux', 'This test is skipped on [Linux].');

--- a/tests/Unit/SecretGenerators/MacSecretGeneratorTest.php
+++ b/tests/Unit/SecretGenerators/MacSecretGeneratorTest.php
@@ -13,12 +13,15 @@ test('generates a secret hash on mac machines', function (): void {
     $actual = $secretGenerator->generate();
 
     expect($actual)->not()->toBeNull();
-})->coversClass(MacSecretGenerator::class)->onlyOnMac();
+})
+    ->coversClass(MacSecretGenerator::class)
+    ->skip(fn(): bool => PHP_OS_FAMILY !== 'Darwin', 'This test is skipped on [' . PHP_OS_FAMILY . '].');
 
 test('throws an exception if secret hash could not be generated', function (): void {
     $secretGenerator = new MacSecretGenerator();
 
     $secretGenerator->generate();
 })
-    ->throws(SecretGenerationException::class)->skipOnMac()
-    ->coversClass(MacSecretGenerator::class)->onlyOnMac();
+    ->throws(SecretGenerationException::class)
+    ->coversClass(MacSecretGenerator::class)
+    ->skip(fn(): bool => PHP_OS_FAMILY === 'Darwin', 'This test is skipped on [Mac].');

--- a/tests/Unit/SecretGenerators/MacSecretGeneratorTest.php
+++ b/tests/Unit/SecretGenerators/MacSecretGeneratorTest.php
@@ -19,4 +19,6 @@ test('throws an exception if secret hash could not be generated', function (): v
     $secretGenerator = new MacSecretGenerator();
 
     $secretGenerator->generate();
-})->throws(SecretGenerationException::class)->skipOnMac();
+})
+    ->throws(SecretGenerationException::class)->skipOnMac()
+    ->coversClass(MacSecretGenerator::class)->onlyOnMac();

--- a/tests/Unit/SecretGenerators/MacSecretGeneratorTest.php
+++ b/tests/Unit/SecretGenerators/MacSecretGeneratorTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\SecretGenerators;
+
+use Serializor\SecretGenerators\MacSecretGenerator;
+use Serializor\SecretGenerators\SecretGenerationException;
+
+test('generates a secret hash on mac machines', function (): void {
+    $secretGenerator = new MacSecretGenerator();
+
+    $actual = $secretGenerator->generate();
+
+    expect($actual)->not()->toBeNull();
+})->coversClass(MacSecretGenerator::class)->onlyOnMac();
+
+test('throws an exception if secret hash could not be generated', function (): void {
+    $secretGenerator = new MacSecretGenerator();
+
+    $secretGenerator->generate();
+})->throws(SecretGenerationException::class)->skipOnMac();

--- a/tests/Unit/SecretGenerators/SecretGeneratorFactoryTest.php
+++ b/tests/Unit/SecretGenerators/SecretGeneratorFactoryTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\SecretGenerators;
+
+use Serializor\SecretGenerators\BsdSecretGenerator;
+use Serializor\SecretGenerators\FallbackSecretGenerator;
+use Serializor\SecretGenerators\LinuxSecretGenerator;
+use Serializor\SecretGenerators\MacSecretGenerator;
+use Serializor\SecretGenerators\SecretGeneratorFactory;
+use Serializor\SecretGenerators\SolarisSecretGenerator;
+use Serializor\SecretGenerators\WindowsSecretGenerator;
+
+test('creates a fitting secret generator for every platform', function (string $platform, string $expected): void {
+    $factory = new SecretGeneratorFactory('');
+
+    $actual = $factory->create($platform);
+
+    expect($actual)->toBeInstanceOf($expected);
+})
+    ->with([
+        'Windows' => ['Windows', WindowsSecretGenerator::class],
+        'Linux'   => ['Linux', LinuxSecretGenerator::class],
+        'Darwin'  => ['Darwin', MacSecretGenerator::class],
+        'Solaris' => ['Solaris', SolarisSecretGenerator::class],
+        'BSD'     => ['BSD', BsdSecretGenerator::class],
+        'unknown' => ['unknown', FallbackSecretGenerator::class],
+        '321364>' => ['321364>', FallbackSecretGenerator::class],
+    ])
+    ->coversClass(SecretGeneratorFactory::class);

--- a/tests/Unit/SecretGenerators/SolarisSecretGeneratorTest.php
+++ b/tests/Unit/SecretGenerators/SolarisSecretGeneratorTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\SecretGenerators;
+
+use Serializor\SecretGenerators\SecretGenerationException;
+use Serializor\SecretGenerators\SolarisSecretGenerator;
+
+test('generates a secret hash on solaris machines', function (): void {
+    $secretGenerator = new SolarisSecretGenerator();
+
+    $actual = $secretGenerator->generate();
+
+    expect($actual)->not()->toBeNull();
+})->coversClass(SolarisSecretGenerator::class)
+    ->skip(fn(): bool => PHP_OS_FAMILY !== 'Solaris', 'This test is skipped on [' . PHP_OS_FAMILY . '].');
+
+test('throws an exception if secret hash could not be generated', function (): void {
+    $secretGenerator = new SolarisSecretGenerator();
+
+    $secretGenerator->generate();
+})
+    ->throws(SecretGenerationException::class)
+    ->coversClass(SolarisSecretGenerator::class)
+    ->skip(fn(): bool => PHP_OS_FAMILY === 'Solaris', 'This test is skipped on [Solaris].');

--- a/tests/Unit/SecretGenerators/WindowsSecretGeneratorTest.php
+++ b/tests/Unit/SecretGenerators/WindowsSecretGeneratorTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\SecretGenerators;
+
+use Serializor\SecretGenerators\SecretGenerationException;
+use Serializor\SecretGenerators\WindowsSecretGenerator;
+
+test('generates a secret hash on windows machines', function (): void {
+    $secretGenerator = new WindowsSecretGenerator();
+
+    $actual = $secretGenerator->generate();
+
+    expect($actual)->not()->toBeNull();
+})->coversClass(WindowsSecretGenerator::class)->onlyOnWindows();
+
+test('throws an exception if secret hash could not be generated', function (): void {
+    $secretGenerator = new WindowsSecretGenerator();
+
+    $secretGenerator->generate();
+})->throws(SecretGenerationException::class)->skipOnWindows();

--- a/tests/Unit/SecretGenerators/WindowsSecretGeneratorTest.php
+++ b/tests/Unit/SecretGenerators/WindowsSecretGeneratorTest.php
@@ -19,4 +19,6 @@ test('throws an exception if secret hash could not be generated', function (): v
     $secretGenerator = new WindowsSecretGenerator();
 
     $secretGenerator->generate();
-})->throws(SecretGenerationException::class)->skipOnWindows();
+})
+    ->throws(SecretGenerationException::class)->skipOnWindows()
+    ->coversClass(WindowsSecretGenerator::class)->onlyOnWindows();

--- a/tests/Unit/SecretGenerators/WindowsSecretGeneratorTest.php
+++ b/tests/Unit/SecretGenerators/WindowsSecretGeneratorTest.php
@@ -7,18 +7,23 @@ namespace Tests\Unit\SecretGenerators;
 use Serializor\SecretGenerators\SecretGenerationException;
 use Serializor\SecretGenerators\WindowsSecretGenerator;
 
+use const PHP_OS_FAMILY;
+
 test('generates a secret hash on windows machines', function (): void {
     $secretGenerator = new WindowsSecretGenerator();
 
     $actual = $secretGenerator->generate();
 
     expect($actual)->not()->toBeNull();
-})->coversClass(WindowsSecretGenerator::class)->onlyOnWindows();
+})
+    ->coversClass(WindowsSecretGenerator::class)
+    ->skip(fn(): bool => PHP_OS_FAMILY !== 'Windows', 'This test is skipped on [' . PHP_OS_FAMILY . '].');
 
 test('throws an exception if secret hash could not be generated', function (): void {
     $secretGenerator = new WindowsSecretGenerator();
 
     $secretGenerator->generate();
 })
-    ->throws(SecretGenerationException::class)->skipOnWindows()
-    ->coversClass(WindowsSecretGenerator::class)->onlyOnWindows();
+    ->throws(SecretGenerationException::class)
+    ->coversClass(WindowsSecretGenerator::class)
+    ->skip(fn(): bool => PHP_OS_FAMILY === 'Windows', 'This test is skipped on [Windows].');


### PR DESCRIPTION
I think this might simplify the secret generation process and relies less on various (potentially editable) files.

Currently 'BSD' and 'Solaris' are not supported. 

I can test this only on windows as I have no access to other machines - so testing on the other platforms is advised.